### PR TITLE
Parse req.params.cat_id to Number

### DIFF
--- a/Testing/04. Testing Web Servers/src/app.js
+++ b/Testing/04. Testing Web Servers/src/app.js
@@ -19,7 +19,7 @@ app.get('/cats', (req, res) => {
 });
 
 app.get('/cats/:cat_id', (req, res) => {
-    let cat = cats.filter(cat => cat.id === req.params.cat_id)[0];
+    let cat = cats.filter(cat => cat.id === Number(req.params.cat_id))[0];
 
     if (cat === undefined) {
         return res.status(400).send({ error_code: 'CAT_NOT_FOUND' });


### PR DESCRIPTION
- Context
`cat.id === req.params.cat_id` will always return `false` since `cat.id` is `Number` but `req.params.cat_id` is `String` so we need to parse the second one to `Number` so it can return true if the value is same